### PR TITLE
Remove completed numbers from possible selections

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -19,7 +19,7 @@ class GameController < ApplicationController
       Turbo::StreamsChannel.broadcast_replace_to(match.match_key, target: 'waiting_for_challenger_container', html: game_over_html)
       Turbo::StreamsChannel.broadcast_replace_to(match.match_key, target: 'player_2_accept_challenge_container', html: game_over_html)
     else
-      render json: { is_correct: is_correct, game_over: game.game_over? }
+      render json: { is_correct: is_correct, game_over: game.game_over?, remaining_numbers: game.remaining_numbers }
     end
   end
 end

--- a/app/javascript/controllers/board_controller.js
+++ b/app/javascript/controllers/board_controller.js
@@ -74,6 +74,7 @@ export default class extends Controller {
     if (selectedCell === undefined) { return }
     if (selectedCell.classList.contains("prefilledCell")) { return }
     if (selectedCell.classList.contains("correctSelection")) { return }
+    if (event.target.classList.contains("d-none")) { return } // Do nothing for keyboard users for completed numbers
 
     const selectedNumber = event.target.innerText;
     const cellIndex = selectedCell.id;
@@ -84,12 +85,19 @@ export default class extends Controller {
       if (response.ok) {
         const bodyPromise = response.json
         bodyPromise.then((body) => {
-          const is_correct   = body.is_correct
-          const is_game_over = body.game_over
+          const is_correct        = body.is_correct
+          const is_game_over      = body.game_over
+          const remaining_numbers = Array.from(body.remaining_numbers)
 
           if (is_correct) {
             selectedCell.classList.remove("incorrectSelection")
             selectedCell.classList.add("correctSelection")
+            if (!remaining_numbers.includes(parseInt(selectedNumber))) {
+              // Hide the number from selection options since
+              // it is no longer a remaining number (i.e. it has been
+              // completed).
+              document.getElementById(`select_${selectedNumber}`).classList.add('d-none')
+            }
           } else {
             selectedCell.classList.add("incorrectSelection")
           }
@@ -111,6 +119,7 @@ export default class extends Controller {
   }
 
   startEditing() {
+    // TODO: Need to get this working at some point
     let editRow = document.getElementById("editRow");
     let selectionRow = document.getElementById('selectionRow')
     editRow.hidden = false;
@@ -118,6 +127,7 @@ export default class extends Controller {
   }
 
   stopEditing() {
+    // TODO: Need to get this working at some point
     let editRow = document.getElementById("editRow");
     let selectionRow = document.getElementById('selectionRow')
     editRow.hidden = true;

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,10 @@
 class Game < ApplicationRecord
   belongs_to :match
 
+  # Records all the selections the player has made.
+  # @param [Integer] selected_value
+  # @param [Integer] selected_cell
+  # @param [Boolean] is_correct
   def record_selection!(selected_value, selected_cell, is_correct)
     self.submissions ||= []
     self.submissions << {
@@ -11,6 +15,28 @@ class Game < ApplicationRecord
     }
 
     self.save!
+  end
+
+  # The current board with all the correct moves
+  # the player has played up until now.
+  # @return [Array]
+  def current_board
+    board               = self.match.starting_board.dup
+    correct_submissions = (self.submissions || []).select { |s| s.fetch('is_correct') }
+    correct_submissions.each do |submission|
+      board[submission.fetch('selected_cell').to_i] = submission.fetch('selected_value').to_i
+    end
+
+    board
+  end
+
+  # Returns numbers that haven't been completed yet.
+  # i.e. If a number hasn't been correctly placed in all
+  # nine of it's cells, it's considered to be remaining.
+  def remaining_numbers
+    (1..9).to_a.select do |number|
+      current_board.count(number) < 9
+    end
   end
 
   def game_over?

--- a/app/views/home/_available_selections.slim
+++ b/app/views/home/_available_selections.slim
@@ -1,6 +1,6 @@
 #selectionRow.row
   .col-md-10.col-sm-12
-    div.mt-4.mb-4.row
+    div.ms-4.mt-4.mb-4.row
       - (1..9).each do |num|
         div.col.btn.btn-primary.me-2 data-action="click->board#makeSelection" id="select_#{num}"
           | #{num}


### PR DESCRIPTION
[Screencast from 06-17-2023 11:24:51 PM.webm](https://github.com/happy-software/sudoku-versus/assets/1514459/38fa7908-86c5-4cb5-b492-f5bd3cf93125)

# Summary

When a number has been completed correctly (i.e. all nine of a specific number have been placed in their correct spots), we remove the number from a possible selection so the user can't choose it anymore.