### PR TITLE
ActionDispatch::SSL is not present in the middleware stack during ass…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   config.force_ssl = false
 
   # Ensure Rails correctly detects HTTPS requests
-  config.middleware.insert_before ActionDispatch::SSL, Rack::Rewrite do
+  config.middleware.use Rack::Rewrite do
     r.env['HTTPS'] = 'on' if r.env['HTTP_X_FORWARDED_PROTO'] == 'https'
   end
 


### PR DESCRIPTION
…et precompilation. Since asset precompilation does not involve handling web requests, some middleware (like SSL handling) might not be loaded. This was causing issues at deploy; This will ensure that the rewrite rule is applied without depending on other middleware.